### PR TITLE
マイページに取引中タブ追加

### DIFF
--- a/src/app/Http/Controllers/MypageController.php
+++ b/src/app/Http/Controllers/MypageController.php
@@ -28,6 +28,18 @@ class MypageController extends Controller
                 ->with('item')
                 ->get()
                 ->pluck('item'); // itemデータのみ抽出
+        } elseif ($currentTab === 'transaction') {
+            // 取引中の商品
+            $sellingItems = Item::where('user_id', $user->id)
+                ->where('status', 'sold')
+                ->get();
+
+            $purchasedItems = Order::where('user_id', $user->id)
+                ->with('item')
+                ->get()
+                ->pluck('item');
+
+            $items = $sellingItems->concat($purchasedItems);
         }
 
         // プロフィール情報を取得

--- a/src/app/Http/Controllers/PurchaseController.php
+++ b/src/app/Http/Controllers/PurchaseController.php
@@ -126,7 +126,7 @@ class PurchaseController extends Controller
 
     public function handleSuccess()
     {
-        return redirect()->route('mypage', ['tab' => 'buy'])->with('success', '購入が完了しました。');
+        return redirect()->route('mypage', ['tab' => 'buy'])->with('success', '購入が完了しました。取引中の商品から取引を続けてください。');
     }
 
     public function handleCancel(Item $item)

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -27,6 +27,7 @@
     <x-tabs :tabs="[
         ['key' => 'sell', 'label' => '出品した商品', 'url' => route('mypage', ['tab' => 'sell'])],
         ['key' => 'buy', 'label' => '購入した商品', 'url' => route('mypage', ['tab' => 'buy'])],
+        ['key' => 'transaction', 'label' => '取引中の商品', 'url' => route('mypage', ['tab' => 'transaction'])],
     ]" :current-tab="$currentTab" />
 
     <div class="product-grid">


### PR DESCRIPTION
## 概要
マイページに「取引中」タブを追加し、ユーザーが出品または購入した取引中の商品を一覧表示できるようにしました。

## 変更内容
- `MypageController.php`
  - 取引中タブ (`tab=transaction`) の場合に、以下の条件で商品を取得
    - 出品した商品 (`items` テーブル) で `status = 'sold'` のもの
    - 購入した商品 (`orders` テーブル) 
  - 取得データを統合し、ビューに渡す処理を実装
- `mypage.blade.php`
  - 「取引中」タブのUIを追加
  - タブの選択状態を管理し、適切なデータを表示

## 動作確認
1. ログイン後、マイページに遷移
2. 「取引中」タブを選択
3. 取引中の出品商品・購入商品が正しく表示されることを確認
4. 他のタブ（「出品した商品」「購入した商品」）の動作に影響がないことを確認

## 影響範囲
- マイページ (`mypage.blade.php`) のレイアウト変更
- `MypageController.php` のロジック変更
---
