### PR TITLE
取引チャット機能実装

### DIFF
--- a/src/app/Http/Controllers/MessageController.php
+++ b/src/app/Http/Controllers/MessageController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\MessageRequest;
+use App\Models\Item;
+use App\Models\Message;
+
+class MessageController extends Controller
+{
+    public function create(Item $item)
+    {
+        $item->load('order.user.profile');
+
+        $messages = $item->messages()
+            ->with('user.profile')
+            ->orderBy('created_at', 'asc')
+            ->get();
+
+        return view('trading', compact('item', 'messages'));
+    }
+
+    public function store(MessageRequest $request, Item $item)
+    {
+        if ($request->hasFile('image_path')) {
+            $path = $request->file('image_path')->store('messages', 'public');
+            $request->image_path = $path;
+        }
+
+        Message::create([
+            'user_id' => auth()->id(),
+            'item_id' => $item->id,
+            'body' => $request->body,
+            'image_path' => $request->image_path,
+        ]);
+
+        return redirect()->route('trading.create', ['item' => $item]);
+    }
+
+    public function update(MessageRequest $request, Item $item, Message $message)
+    {
+        $message->update($request->only('body'));
+
+        return redirect()->route('trading.create', ['item' => $item]);
+    }
+
+    public function destroy(Item $item, Message $message)
+    {
+        $message->delete();
+
+        return redirect()->route('trading.create', ['item' => $item]);
+    }
+}

--- a/src/app/Http/Controllers/StripeWebhookController.php
+++ b/src/app/Http/Controllers/StripeWebhookController.php
@@ -108,6 +108,7 @@ class StripeWebhookController extends Controller
                 $item = Item::find($order->item_id);
                 if ($item) {
                     $item->status = 'sold';
+                    $item->trading_status = 'progression';
                     $item->save();
                 }
 

--- a/src/app/Http/Requests/MessageRequest.php
+++ b/src/app/Http/Requests/MessageRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => 'required|string|max:400',
+            'image_path' => 'nullable|image|mimes:jpeg,png|max:2048',
+        ];
+    }
+
+    /**
+     * Get the validation messages that apply to the request.
+     * 
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'body.required' => '本文を入力してください',
+            'body.string' => '本文は文字列で入力してください',
+            'body.max' => '本文は400文字以内で入力してください',
+            'image_path.image' => '画像ファイルでアップロードしてください',
+            'image_path.mimes' => ' 「.png」または「.jpeg」形式でアップロードしてください',
+            'image_path.max' => '2MB以下のファイルをアップロードしてください',
+        ];
+    }
+}

--- a/src/app/Models/Item.php
+++ b/src/app/Models/Item.php
@@ -41,4 +41,19 @@ class Item extends Model
         return $this->hasMany(Comment::class);
     }
 
+    public function order()
+    {
+        return $this->hasOne(Order::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+
 }

--- a/src/app/Models/Message.php
+++ b/src/app/Models/Message.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'item_id',
+        'body',
+        'image_path',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -47,4 +47,9 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasOne(Profile::class);
     }
+
+    public function items()
+    {
+        return $this->hasMany(Item::class);
+    }
 }

--- a/src/app/View/Components/ProductCard.php
+++ b/src/app/View/Components/ProductCard.php
@@ -34,7 +34,7 @@ class ProductCard extends Component
     public function getUrl()
     {
         if ($this->context === 'mypage' && $this->item->trading_status === 'progression') {
-            return route('trading');
+            return route('trading.create', ['item' => $this->item->id]);
         } else {
             return route('item', ['item' => $this->item->id]);
         }

--- a/src/database/migrations/2025_03_04_093322_create_messages_table.php
+++ b/src/database/migrations/2025_03_04_093322_create_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('item_id')->constrained()->cascadeOnDelete();
+            $table->string('body', 400);
+            $table->string('image_path', 255)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/src/public/css/trading.css
+++ b/src/public/css/trading.css
@@ -1,13 +1,14 @@
 /* デフォルトスタイル */
 .trading__container {
     display: flex;
+    height: 100%
 }
 
 /* サイドバー */
 .trading__sidebar {
     background: #868686;
     width: 17vw;
-    height: 100vh;
+    min-height: 100vh;
     padding: 1vw 0;
 }
 
@@ -70,6 +71,13 @@
     border-radius: 50%;
 }
 
+.trading__avatar img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
 .trading__avatar--large {
     width: 5.33vw;
     height: 5.33vw;
@@ -104,6 +112,12 @@
     background-color: #ccc;
     width: 13.3vw;
     height: 13.3vw;
+}
+
+.trading__product-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .trading__product-details {
@@ -160,6 +174,7 @@
 .trading__message-body {
     display: inline-block;
     background-color: #D9D9D9;
+    border: none;
     width: 30.7vw;
     padding: 1vw;
     font-size: 1vw;
@@ -168,12 +183,25 @@
     border-radius: 0.33vw;
 }
 
+.trading__message-image {
+    display: block;
+    background-color: #ccc;
+    object-fit: cover;
+    width: 32.7vw;
+    height: 32.7vw;
+    margin-bottom: 0.67vw;
+}
+
 .trading__message--right .trading__message-body {
     text-align: left;
 }
 
+.trading__message--right .trading__message-image {
+    margin-left: auto;
+}
+
 .trading__message-link {
-    text-decoration: none;
+    all:unset;
     color: #aaa;
     margin-left: 1vw;
     font-size: 1vw;
@@ -184,11 +212,19 @@
     color: #FF8282;
 }
 
+.trading__edit-form,
+.trading__delete-form {
+    display: inline;
+}
+
 .trading__chat-input {
+    margin-top: 2vw;
+}
+
+.trading__message-form {
     display: flex;
     align-items: center;
     gap: 0.67vw;
-    margin-top: 2vw;
 }
 
 .trading__input {
@@ -228,6 +264,10 @@
 
 .trading__icon-button:hover {
     color: #5F5F5F;
+}
+
+.error-message {
+    margin-left: 0.33vw;
 }
 
 @media screen and (min-width: 1400px) and (max-width: 1540px) {
@@ -345,14 +385,23 @@
         border-radius: 5px;
     }
 
+    .trading__message-image {
+        width: 480px;
+        height: 480px;
+        margin-bottom: 10px;
+    }
+
     .trading__message-link {
         margin-left: 15px;
         font-size: 16px;
     }
 
     .trading__chat-input {
-        gap: 10px;
         margin-top: 30px;
+    }
+
+    .trading__message-form {
+        gap: 10px;
     }
 
     .trading__input {
@@ -373,6 +422,10 @@
 
     .bi-send {
         font-size: 37px;
+    }
+
+    .error-message {
+        margin-left: 5px;
     }
 }
 
@@ -491,14 +544,23 @@
         border-radius: 3px;
     }
 
+    .trading__message-image {
+        width: 256px;
+        height: 256px;
+        margin-bottom: 6px;
+    }
+
     .trading__message-link {
         margin-left: 8px;
         font-size: 10px;
     }
 
     .trading__chat-input {
-        gap: 6px;
         margin-top: 18px;
+    }
+
+    .trading__message-form {
+        gap: 6px;
     }
 
     .trading__input {
@@ -519,5 +581,9 @@
 
     .bi-send {
         font-size: 20px;
+    }
+
+    .error-message {
+        margin-left: 3px;
     }
 }

--- a/src/resources/views/trading.blade.php
+++ b/src/resources/views/trading.blade.php
@@ -27,55 +27,108 @@
         <div class="trading__content">
             <section class="trading__header">
                 <div class="trading__header-container">
-                    <div class="trading__avatar trading__avatar--large"></div>
-                    <h1 class="trading__heading">「ユーザー名」さんとの取引画面</h1>
+                    <div class="trading__avatar trading__avatar--large">
+                        @if ($item->user_id !== auth()->id())
+                            <img src="{{ asset('storage/' . $item->user?->profile?->image_path) }}" alt="プロフィール画像">
+                        @else
+                            <img src="{{ asset('storage/' . $item->order?->user?->profile?->image_path) }}" alt="プロフィール画像">
+                        @endif
+                    </div>
+
+                    @if ($item->user_id !== auth()->id())
+                        <h1 class="trading__heading">{{ $item->user?->name }}さんとの取引画面</h1>
+                    @else
+                        <h1 class="trading__heading">{{ $item->order?->user?->name }}さんとの取引画面</h1>
+                    @endif
                 </div>
                 <button class="trading__button trading__button--complete">取引を完了する</button>
             </section>
 
             <section class="trading__product-info">
-                <div class="trading__product-image">商品画像</div>
+                <div class="trading__product-image">
+                    <img src="{{ asset('storage/' . $item->image_path) }}" alt="{{ $item->name }}">
+                </div>
                 <div class="trading__product-details">
-                    <h2 class="trading__subheading">商品名</h2>
-                    <p>商品価格</p>
+                    <h2 class="trading__subheading">{{ $item->name }}</h2>
+                    <p>¥{{ number_format($item->price) }}</p>
                 </div>
             </section>
 
             <section class="trading__chat">
                 <div class="trading__messages">
-                    <div class="trading__message trading__message--left">
-                        <div class="trading__user trading__user--left">
-                            <div class="trading__avatar"></div>
-                            <div class="trading__user-name">ユーザー名</div>
+                    @foreach ($messages as $message)
+                        @php
+                            // ログインユーザー自身のメッセージかどうか
+                            $isOwnMessage = $message->user_id === auth()->id();
+                        @endphp
+
+                        <div class="trading__message {{ $isOwnMessage ? 'trading__message--right' : 'trading__message--left' }}">
+                            <div class="trading__user {{ $isOwnMessage ? 'trading__user--right' : 'trading__user--left' }}">
+                                @if ($isOwnMessage)
+                                    {{-- 自分の名前・アイコン --}}
+                                    <div class="trading__user-name">{{ Auth::user()->name }}</div>
+                                    <div class="trading__avatar">
+                                        <img src="{{ asset('storage/' . Auth::user()->profile?->image_path) }}" alt="プロフィール画像">
+                                    </div>
+                                @else
+                                    {{-- 相手の名前・アイコン --}}
+                                    <div class="trading__avatar">
+                                        <img src="{{ asset('storage/' . $message->user?->profile?->image_path) }}" alt="プロフィール画像">
+                                    </div>
+                                    <div class="trading__user-name">{{ $message->user?->name }}</div>
+                                @endif
+                            </div>
+
+                            {{-- メッセージ本文 --}}
+                            @if ($isOwnMessage)
+                                {{-- 自分のメッセージ --}}
+                                <textarea class="trading__message-body" name="body" form="message-edit-{{ $message->id }}" rows="1">{{ old('body', $message->body) }}</textarea>
+
+                                @if ($message->image_path)
+                                    <img class="trading__message-image" src="{{ asset('storage/' . $message->image_path) }}" alt="アップロード画像">
+                                @endif
+
+                                <div class="trading__message-links">
+                                    <form class="trading__edit-form" action="{{ route('trading.message.update', ['item' => $item, 'message' => $message]) }}" method="POST" id="message-edit-{{ $message->id }}">
+                                        @csrf
+                                        @method('PATCH')
+                                        <button class="trading__message-link" type="submit">編集</button>
+                                    </form>
+                                    <form class="trading__delete-form" action="{{ route('trading.message.destroy', ['item' => $item, 'message' => $message]) }}" method="POST">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button class="trading__message-link" type="submit">削除</button>
+                                    </form>
+                                </div>
+                            @else
+                                {{-- 相手のメッセージ --}}
+                                <p class="trading__message-body">{{ $message->body }}</p>
+
+                                @if ($message->image_path)
+                                    <img class="trading__message-image" src="{{ asset('storage/' . $message->image_path) }}" alt="アップロード画像">
+                                @endif
+                            @endif
                         </div>
-
-                        <p class="trading__message-body">購入しました。最後まで取引よろしくお願いします。</p>
-                    </div>
-
-                    <div class="trading__message trading__message--right">
-                        <div class="trading__user trading__user--right">
-                            <div class="trading__user-name">あなた</div>
-                            <div class="trading__avatar"></div>
-                        </div>
-
-                        <p class="trading__message-body">ご購入ありがとうございます。発送まで今しばらくお待ちください。</p>
-
-                        <div class="trading__message-links">
-                            <a class="trading__message-link" href="">編集</a>
-                            <a class="trading__message-link" href="">削除</a>
-                        </div>
-                    </div>
+                    @endforeach
                 </div>
 
+                {{-- メッセージ投稿フォーム --}}
                 <div class="trading__chat-input">
-                    <input class="trading__input" type="text" placeholder="取引メッセージを入力してください">
+                    <x-validation-error field="body" />
+                    <x-validation-error field="image_path" />
 
-                    <label class="trading__label-button" for="image">
-                        画像を追加
-                        <input type="file" name="image_path" accept=".jpeg,.png" id="image">
-                    </label>
+                    <form class="trading__message-form" action="{{ route('trading.message.store', ['item' => $item]) }}" method="POST" enctype="multipart/form-data">
+                        @csrf
 
-                    <button class="trading__icon-button"><i class="bi bi-send"></i></button>
+                        <input class="trading__input" type="text" name="body" placeholder="取引メッセージを入力してください" value="{{ old('body') }}">
+
+                        <label class="trading__label-button" for="image">
+                            画像を追加
+                            <input type="file" name="image_path" accept=".jpeg,.png" id="image">
+                        </label>
+
+                        <button class="trading__icon-button" type="submit"><i class="bi bi-send"></i></button>
+                    </form>
                 </div>
             </section>
         </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\PurchaseController;
 use App\Http\Controllers\AddressController;
 use App\Http\Controllers\VerifyEmailController;
 use App\Http\Controllers\StripeWebhookController;
+use App\Http\Controllers\MessageController;
 
 /*
 |--------------------------------------------------------------------------
@@ -69,9 +70,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/purchase/cancel/{item}', [PurchaseController::class, 'handleCancel'])->name('purchase.cancel');
 
     // 取引関連(商品購入後)
-    Route::get('/trading', function () {
-        return view('trading');
-    })->name('trading');
+    Route::get('/trading/{item}', [MessageController::class, 'create'])->name('trading.create');
+
+    Route::post('/trading/{item}/message', [MessageController::class, 'store'])->name('trading.message.store');
+
+    Route::patch('/trading/{item}/message/{message}', [MessageController::class, 'update'])->name('trading.message.update');
+
+    Route::delete('/trading/{item}/message/{message}', [MessageController::class, 'destroy'])->name('trading.message.destroy');
 });
 
  // デフォルトのメール認証ルートを上書き


### PR DESCRIPTION
## 概要
取引チャット機能を実装しました。本機能により、購入者と出品者がメッセージをやり取りできるようになります。  
メッセージの投稿、編集、削除が可能で、本文の入力に加えて任意で画像の添付もできます。  

## 実装内容
以下の内容を実装しました。  

### 1. **データベースの設計・マイグレーション**
- `messages` テーブルの作成
  - `id`: メッセージID
  - `item_id`: 商品ID（取引対象の商品）
  - `user_id`: 送信者のユーザーID
  - `body`: メッセージ本文
  - `image_path`: 画像の保存パス（任意）
  - `created_at`: 作成日時
  - `updated_at`: 更新日時

### 2. **モデルの作成**
- `Message` モデルを作成し、リレーションを定義
  - `Item`（取引対象の商品）との関連付け
  - `User`（メッセージ送信者）との関連付け

### 3. **コントローラーの作成**
- `MessageController` の作成
  - `index`: 取引チャット画面を表示
  - `store`: メッセージの投稿処理
  - `update`: メッセージの編集処理
  - `destroy`: メッセージの削除処理

### 4. **フォームリクエストの作成**
- `MessageRequest` を作成し、バリデーションを実装
  - `body`: 必須（最大 400 文字）
  - `image_path`: 任意（jpeg, png のみ許可、最大 2MB）

### 5. **Bladeテンプレートの実装**
- メッセージ一覧を時系列順に表示
- 自分のメッセージは右側、相手のメッセージは左側に表示
- メッセージ投稿フォームを実装
- メッセージの編集・削除機能を実装

## 動作確認
- 出品者としてメッセージを送信・編集・削除できることを確認
- 購入者としてメッセージを送信・編集・削除できることを確認
- 送信されたメッセージが適切に時系列順で表示されることを確認
- 画像のアップロード・表示が正しく機能することを確認
- メッセージのバリデーションが適用されていることを確認

## 影響範囲
- 取引チャット画面（`resources/views/trading/chat.blade.php`）
- メッセージの投稿・編集・削除機能
- 商品の詳細画面（チャット画面へのリンクが追加された場合）

---